### PR TITLE
feat(cli): Added cli-config-file option.

### DIFF
--- a/.changeset/slimy-cameras-jog.md
+++ b/.changeset/slimy-cameras-jog.md
@@ -1,0 +1,5 @@
+---
+"@swc/cli": patch
+---
+
+feat(cli): Added cli-config-file option.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "dependencies": {
         "@mole-inc/bin-wrapper": "^8.0.1",
         "@swc/counter": "workspace:^",
-        "commander": "^7.1.0",
+        "commander": "^8.3.0",
         "fast-glob": "^3.2.5",
         "minimatch": "^9.0.3",
         "piscina": "^4.3.0",

--- a/packages/cli/src/spack/options.ts
+++ b/packages/cli/src/spack/options.ts
@@ -9,25 +9,26 @@ export interface SpackCliOptions {
     debug: boolean;
 }
 
-commander.option("--config [path]", "Path to a spack.config.js file to use.");
+const program = new commander.Command();
+program.option("--config [path]", "Path to a spack.config.js file to use.");
 // TODO: allow using ts. See: https://github.com/swc-project/swc/issues/841
 
-commander.option("--mode <development | production | none>", "Mode to use");
-commander.option("--target [browser | node]", "Target runtime environment");
+program.option("--mode <development | production | none>", "Mode to use");
+program.option("--target [browser | node]", "Target runtime environment");
 
-commander.option(
+program.option(
     "--context [path]",
     `The base directory (absolute path!) for resolving the 'entry'` +
         ` option. If 'output.pathinfo' is set, the included pathinfo is shortened to this directory`,
     "The current directory"
 );
 
-commander.option("--entry [list]", "List of entries", collect);
+program.option("--entry [list]", "List of entries", collect);
 
-// commander.option('-W --watch', `Enter watch mode, which rebuilds on file change.`)
+// program.option('-W --watch', `Enter watch mode, which rebuilds on file change.`)
 
-commander.option("--debug", `Switch loaders to debug mode`);
-// commander.option('--devtool', `Select a developer tool to enhance debugging.`)
+program.option("--debug", `Switch loaders to debug mode`);
+// program.option('--devtool', `Select a developer tool to enhance debugging.`)
 
 // -d           shortcut for --debug --devtool eval-cheap-module-source-map
 //              --output-pathinfo                                          [여부]
@@ -40,11 +41,11 @@ commander.option("--debug", `Switch loaders to debug mode`);
 // --module-bind-pre   Bind an extension to a pre loader                 [문자열]
 
 // Output options:
-commander.option(
+program.option(
     "-o --output",
     `The output path and file for compilation assets`
 );
-commander.option("--output-path", `The output directory as **absolute path**`);
+program.option("--output-path", `The output directory as **absolute path**`);
 //   --output-filename             Specifies the name of each output file on disk.
 //                                 You must **not** specify an absolute path here!
 //                                 The `output.path` option determines the location
@@ -158,7 +159,7 @@ commander.option("--output-path", `The output directory as **absolute path**`);
 //   --silent       Prevent output from being displayed in stdout         [boolean]
 //   --json, -j     Prints the result as JSON.                            [boolean]
 
-commander.version(
+program.version(
     `@swc/cli: ${pkg.version}
 @swc/core: ${swcCoreVersion}`
 );
@@ -168,7 +169,7 @@ export default async function parseSpackArgs(args: string[]): Promise<{
     spackOptions: BundleOptions;
 }> {
     //
-    const cmd = commander.parse(args);
+    const cmd = program.parse(args);
     const opts = cmd.opts();
 
     const cliOptions: SpackCliOptions = {

--- a/packages/cli/src/swc/__mocks__/fs.ts
+++ b/packages/cli/src/swc/__mocks__/fs.ts
@@ -3,20 +3,32 @@ import type { Stats } from "fs";
 
 export interface MockHelpers {
     resetMockStats: () => void;
+    resetMockFiles: () => void;
     setMockStats: (stats: Record<string, Stats | Error>) => void;
+    setMockFile: (path: string, contents: string) => void;
 }
 
 const fsMock = jest.createMockFromModule<typeof fs & MockHelpers>("fs");
 
 let mockStats: Record<string, Stats | Error> = {};
+let mockFiles: Record<string, string> = {};
 
 function setMockStats(stats: Record<string, Stats | Error>) {
     Object.entries(stats).forEach(([path, stats]) => {
         mockStats[path] = stats;
     });
 }
+
+function setMockFile(path: string, contents: string) {
+    mockFiles[path] = contents;
+}
+
 function resetMockStats() {
     mockStats = {};
+}
+
+function resetMockFiles() {
+    mockFiles = {};
 }
 
 export function stat(path: string, cb: (err?: Error, stats?: Stats) => void) {
@@ -28,9 +40,21 @@ export function stat(path: string, cb: (err?: Error, stats?: Stats) => void) {
     }
 }
 
+export function readFileSync(path: string): string {
+    if (!mockFiles[path]) {
+        throw new Error("Non existent.");
+    }
+
+    return mockFiles[path];
+}
+
 fsMock.setMockStats = setMockStats;
 fsMock.resetMockStats = resetMockStats;
 
+fsMock.setMockFile = setMockFile;
+fsMock.resetMockFiles = resetMockFiles;
+
 fsMock.stat = stat as typeof fs.stat;
+fsMock.readFileSync = readFileSync as typeof fs.readFileSync;
 
 export default fsMock;

--- a/packages/cli/src/swc/__tests__/options.test.ts
+++ b/packages/cli/src/swc/__tests__/options.test.ts
@@ -1,6 +1,7 @@
 import type { Options } from "@swc/core";
 import deepmerge from "deepmerge";
 import fs from "fs";
+import { resolve } from "path";
 
 jest.mock("fs");
 
@@ -330,7 +331,7 @@ describe("parserArgs", () => {
     describe("--cli-config-file", () => {
         it("reads a JSON config file with both camel and kebab case options", async () => {
             (fs as any).setMockFile(
-                "/swc/cli.json",
+                resolve(process.cwd(), "/swc/cli.json"),
                 JSON.stringify({
                     outFileExtension: "mjs",
                     deleteDirOnStart: "invalid",
@@ -355,7 +356,7 @@ describe("parserArgs", () => {
 
         it("reads a JSON but options are overriden from CLI", async () => {
             (fs as any).setMockFile(
-                "/swc/cli.json",
+                resolve(process.cwd(), "/swc/cli.json"),
                 JSON.stringify({
                     outFileExtension: "mjs",
                     "delete-dir-on-start": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: workspace:^
         version: link:../counter
       commander:
-        specifier: ^7.1.0
-        version: 7.1.0
+        specifier: ^8.3.0
+        version: 8.3.0
       fast-glob:
         specifier: ^3.2.5
         version: 3.3.0
@@ -3492,14 +3492,15 @@ packages:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
 
-  /commander@7.1.0:
-    resolution: {integrity: sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==}
-    engines: {node: '>= 10'}
-    dev: false
-
   /commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+    dev: true
+
+  /commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+    dev: false
 
   /comment-json@4.2.3:
     resolution: {integrity: sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==}
@@ -5249,6 +5250,7 @@ packages:
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
     dev: true
@@ -7442,6 +7444,7 @@ packages:
 
   /node-addon-api@3.2.1:
     resolution: {integrity: sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==}
+    requiresBuild: true
     optional: true
 
   /node-fetch@2.6.12:
@@ -7471,6 +7474,7 @@ packages:
   /node-gyp-build@4.8.0:
     resolution: {integrity: sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==}
     hasBin: true
+    requiresBuild: true
     optional: true
 
   /node-gyp@10.0.1:
@@ -10112,7 +10116,7 @@ packages:
       '@mole-inc/bin-wrapper': 8.0.1
       '@swc/core': 1.3.107
       '@swc/counter': link:packages/counter
-      commander: 7.2.0
+      commander: 8.3.0
       fast-glob: 3.3.0
       minimatch: 9.0.3
       piscina: 4.3.1


### PR DESCRIPTION
This PR add a new option that can point to JSON file.
This file can contain any option supported by CLI (either in `kebab-case` or `camelCase` format) and will applied accordingly.
Other options explicitly provided via command line override the one in the JSON file (so that the file can act as a "template").

Fixes https://github.com/swc-project/cli/issues/284