### PR TITLE
chore(cli): Fix package repository path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/node ./bin/swc-project/pkgs.git"
+        "url": "https://github.com/swc-project/pkgs.git"
     },
     "keywords": [
         "swc",


### PR DESCRIPTION
Using renovate for an internal project at my company, it appeared it raised an error trying to reach the repository for @swc/cli.

Since this looks like a typo, here is a proposal of fix.
