### PR TITLE
feat(cli): Add callbacks to cli

### DIFF
--- a/packages/cli/bin/swc.js
+++ b/packages/cli/bin/swc.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
 process.title = "swc";
-require("../lib/swc");
+require("../lib/swc/bin.js");

--- a/packages/cli/src/swc/__tests__/callback.test.ts
+++ b/packages/cli/src/swc/__tests__/callback.test.ts
@@ -1,0 +1,70 @@
+import { swcDir } from "../index";
+
+jest.mock("../compile", () => ({
+    outputResult: jest.fn(),
+}));
+
+let mockComplie: any;
+
+jest.mock("../dirWorker", () => ({
+    __esModule: true,
+    default: () => mockComplie(),
+}));
+
+const cliOptions: any = {
+    outDir: "./.temp/",
+    watch: false,
+    filenames: ["./src/swcx/"],
+    extensions: [".ts"],
+    stripLeadingPaths: true,
+    sync: true,
+};
+const swcOptions: any = {
+    jsc: {
+        target: "esnext",
+        externalHelpers: false,
+    },
+    module: {
+        type: "commonjs",
+    },
+};
+
+describe("dir callbacks", () => {
+    it("onSuccess should be called", async () => {
+        mockComplie = () => Promise.resolve(1); // mock complie success
+
+        const onSuccess = jest.fn();
+        const onFail = jest.fn();
+
+        await swcDir({
+            cliOptions: cliOptions,
+            swcOptions: swcOptions,
+            callbacks: {
+                onSuccess,
+                onFail,
+            },
+        });
+
+        expect(onSuccess.mock.calls).toHaveLength(1);
+        expect(onFail.mock.calls).toHaveLength(0);
+    });
+
+    it("onFail should be called", async () => {
+        mockComplie = () => Promise.reject(new Error("fail")); // mock complie fail
+
+        const onSuccess = jest.fn();
+        const onFail = jest.fn();
+
+        await swcDir({
+            cliOptions: cliOptions,
+            swcOptions: swcOptions,
+            callbacks: {
+                onSuccess,
+                onFail,
+            },
+        });
+
+        expect(onSuccess.mock.calls).toHaveLength(0);
+        expect(onFail.mock.calls).toHaveLength(1);
+    });
+});

--- a/packages/cli/src/swc/bin.ts
+++ b/packages/cli/src/swc/bin.ts
@@ -1,0 +1,17 @@
+import dirCommand from "./dir";
+import fileCommand from "./file";
+import parseArgs, { initProgram } from "./options";
+
+initProgram();
+const opts = parseArgs(process.argv);
+const fn = opts.cliOptions.outDir ? dirCommand : fileCommand;
+
+process.on("uncaughtException", function (err) {
+    console.error(err);
+    process.exit(1);
+});
+
+fn(opts).catch((err: Error) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/packages/cli/src/swc/dir.ts
+++ b/packages/cli/src/swc/dir.ts
@@ -101,7 +101,9 @@ async function initialCompilation(
                 });
                 results.set(filename, result);
             } catch (err: any) {
-                console.error(err.message);
+                if (!callbacks?.onFail) {
+                    console.error(err.message);
+                }
                 results.set(filename, CompileStatus.Failed);
             }
         }
@@ -114,7 +116,9 @@ async function initialCompilation(
                 );
                 results.set(filename, result);
             } catch (err: any) {
-                console.error(err.message);
+                if (!callbacks?.onFail) {
+                    console.error(err.message);
+                }
                 results.set(filename, CompileStatus.Failed);
             }
         }

--- a/packages/cli/src/swc/index.ts
+++ b/packages/cli/src/swc/index.ts
@@ -1,17 +1,3 @@
-import dirCommand from "./dir";
-import fileCommand from "./file";
-import parseArgs, { initProgram } from "./options";
+import swcDir from "./dir";
 
-initProgram();
-const opts = parseArgs(process.argv);
-const fn = opts.cliOptions.outDir ? dirCommand : fileCommand;
-
-process.on("uncaughtException", function (err) {
-    console.error(err);
-    process.exit(1);
-});
-
-fn(opts).catch((err: Error) => {
-    console.error(err);
-    process.exit(1);
-});
+export { swcDir };

--- a/packages/cli/src/swc/options.ts
+++ b/packages/cli/src/swc/options.ts
@@ -276,6 +276,22 @@ export interface CliOptions {
     readonly ignore: string[];
 }
 
+export interface Callbacks {
+    readonly onSuccess?: (data: {
+        duration: number;
+        /** count of compiled files */
+        compiled?: number;
+        /** count of copied files */
+        copied?: number;
+        filename?: string;
+    }) => any;
+    readonly onFail?: (data: {
+        duration: number;
+        reasons: Map<string, string>;
+    }) => any;
+    readonly onWatchReady?: () => any;
+}
+
 export default function parserArgs(args: string[]) {
     program.parse(args);
     let opts = program.opts();


### PR DESCRIPTION
Closes https://github.com/swc-project/pkgs/issues/55

I rename `packages/cli/src/swc/index.ts` to `packages/cli/src/swc/bin.ts`, and export `swcDir` function via new `packages/cli/src/swc/index.ts`

add doc here: https://github.com/swc-project/website/pull/261