### PR TITLE
docs(cli): Backfill CHANGELOG to start of 2023 - 0.1.60

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -49,3 +49,101 @@
 ### Patch Changes
 
 -   Move to monorepo
+
+## 0.3.5 - Old Repo
+
+### Patch Changes
+
+- [bcba7fc](https://github.com/swc-project/cli/commit/bcba7fc576ea938d9f4c38fd54d63c6c1c984273): Fix `undefined` file extension when interacting with `dir` directly.
+
+## 0.3.4 - Old Repo
+
+### Patch Changes
+
+- [cb15ec9](https://github.com/swc-project/cli/commit/cb15ec9e87da3a509cd9c70485a6ce7b3ce0d47a): Update option defaults
+
+## 0.3.3 - Old Repo
+
+### Patch Changes
+
+- [0e0d745](https://github.com/swc-project/cli/commit/0e0d745c1c31d9148c2464ae624b1db012eb469e): feat(cli): add --out-file-extension (with tests)
+
+## 0.3.2 - Old Repo
+
+### Patch Changes
+
+- [8d8b146](https://github.com/swc-project/cli/commit/8d8b1461a58ed0708b66b68fc5cbd2cffe165f48): Fix for "Cannot read properties of undefined (reading 'stripLeadingPaths')"
+
+## 0.3.1 - Old Repo
+
+### Patch Changes
+
+- [0d8f59a](https://github.com/swc-project/cli/commit/0d8f59aaac4954c3e68f742bb0965343ec82d771): feat: Add `strip-leading-paths` option
+
+## 0.3.0 - Old Repo
+
+### Minor Changes
+
+- [db03ac8](https://github.com/swc-project/cli/commit/db03ac8c3e78118978fb6ab2c3a066c7b66b212e): Removal of `stripComponents`
+
+## 0.2.3 - Old Repo
+
+### Patch Changes
+
+- [4688ea6](https://github.com/swc-project/cli/commit/4688ea6c5f14db30f6ee537bf5b2cc44c39d43a3): Revert removal of `stripComponents`
+
+## 0.2.2 - Old Repo
+
+### Patch Changes
+
+- [3d4e6c7](https://github.com/swc-project/cli/commit/3d4e6c77a03a4bbb6552608463af8a7528484aa9): Removal of `stripComponents`
+
+## 0.2.1 - Old Repo
+
+## 0.2.0 - Old Repo
+
+### Minor Changes
+
+- [7d9a493](https://github.com/swc-project/cli/commit/7d9a493ae37c716515139131ca5df5a6d0f7b97f): Use workers to process files in parallel
+- [908d0a1](https://github.com/swc-project/cli/commit/908d0a1bc07e50284ac355372fb6ac3e58b84268): chore: Update CI - Remove node 14.x + Add node 20.x for integration and test workflows
+
+## 0.1.65 - Old Repo
+
+## 0.1.64 - Old Repo
+
+### Patch Changes
+
+- [52948e9](https://github.com/swc-project/cli/commit/52948e99f817fe2114608ead4293bf8b80a7cfc4): Check for `undefined` in `only`
+- [4f0bd60](https://github.com/swc-project/cli/commit/4f0bd60addf399a47be4f5c3f805073e2221c439): feat: Implement `--only` and `--ignore`
+
+## 0.1.63 - Old Repo
+
+### Patch Changes
+
+- [ff87851](https://github.com/swc-project/cli/commit/ff8785138706d5b6e1d36e90a58453bc1b1c5531): Fix for "Cannot transpile the working directory itself"
+- [dc0f03d](https://github.com/swc-project/cli/commit/dc0f03dfbd381d71fadf04f6e6be1f1504eb6349): Force formatting and fix ci node version requirement - Remove node 12.x + Add node 18.x for integration and test workflows
+
+## 0.1.62 - Old Repo
+
+### Patch Changes
+
+- [d7dc671](https://github.com/swc-project/cli/commit/d7dc671c7c8b5178b2babb78328434325f7197c5): fix: bin.path is not a function
+
+## 0.1.61 - Old Repo
+
+### Patch Changes
+
+- [db1113b](https://github.com/swc-project/cli/commit/db1113bfc575447b7620f6014a2983faf4b9078d): refactor: replace bin-wrapper with @mole-inc/bin-wrapper
+
+## 0.1.60 - Old Repo
+
+### Patch Changes
+
+- [a2f4299](https://github.com/swc-project/cli/commit/a2f429938db80e6e6e0f980e49b4d8b75eaa51db): Fix for "`sourceMappingURL` present when source maps are disabled"
+- [9e45d8c](https://github.com/swc-project/cli/commit/9e45d8c6f40791372e25e0c9192f45f08b5f9bdd): Handle missing dependencies/devDependencies
+
+## Prior to 2023 - Old Repo
+
+### Reference - Git History
+
+- [@swc-project/cli Git History](https://github.com/swc-project/cli/commits/main)


### PR DESCRIPTION
Backfilling CHANGELOG for `@swc/cli`  to start of 2023 - `0.1.60` so that people can keep track of changes in the old repo before it was moved to this new monorepo.

Main focus point is to track the introduction of `--strip-leading-paths`, so that people from `0.1.x` can migrate to `0.4.x`

Fixes Issue: [#22](https://github.com/swc-project/pkgs/issues/22)