### PR TITLE
fix(jest): Handle process.version undefined

### DIFF
--- a/.changeset/good-lobsters-search.md
+++ b/.changeset/good-lobsters-search.md
@@ -1,0 +1,5 @@
+---
+"@swc/jest": patch
+---
+
+Return es2018 in the event that process.version is undefined.

--- a/packages/jest/index.ts
+++ b/packages/jest/index.ts
@@ -144,7 +144,7 @@ function buildSwcTransformOpts(
             computedSwcOptions,
             "jsc.target",
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            nodeTargetDefaults.get(process.version.match(/v(\d+)/)![1]) ||
+            nodeTargetDefaults.get(process.version?.match(/v(\d+)/)![1]) ||
                 "es2018"
         );
     }


### PR DESCRIPTION
In the event that `process.version` is undefined then return "es2018" as expected.