### PR TITLE
Bump piscina to 4.3.1

### DIFF
--- a/.changeset/fresh-fans-beg.md
+++ b/.changeset/fresh-fans-beg.md
@@ -1,0 +1,5 @@
+---
+"@swc/cli": patch
+---
+
+Bump piscina to 4.3.1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
         "commander": "^8.3.0",
         "fast-glob": "^3.2.5",
         "minimatch": "^9.0.3",
-        "piscina": "^4.3.0",
+        "piscina": "^4.3.1",
         "semver": "^7.3.8",
         "slash": "3.0.0",
         "source-map": "^0.7.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^9.0.3
         version: 9.0.3
       piscina:
-        specifier: ^4.3.0
-        version: 4.3.0
+        specifier: ^4.3.1
+        version: 4.3.1
       semver:
         specifier: ^7.3.8
         version: 7.5.3
@@ -64,7 +64,7 @@ importers:
         version: 0.7.4
     devDependencies:
       '@swc/cli':
-        specifier: 0.5.0
+        specifier: 0.5.1
         version: 'link:'
       '@swc/core':
         specifier: ^1.6.4
@@ -8251,12 +8251,6 @@ packages:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
     dev: true
-
-  /piscina@4.3.0:
-    resolution: {integrity: sha512-vTQszGZj78p0BHFNO/cSvpzPUYa4tLXRe30aIYyQjqRS3fK/kPqdxvkTfGXQlEpWOI+mOOkda0iEY6NaanLWJA==}
-    optionalDependencies:
-      nice-napi: 1.0.2
-    dev: false
 
   /piscina@4.3.1:
     resolution: {integrity: sha512-MBj0QYm3hJQ/C/wIXTN1OCYC8uQ4BBJ4LVele2P4ZwVQAH04vkk8E1SpDbuemLAL1dZorbuOob9rYqJeWCcCRg==}


### PR DESCRIPTION
While compiling a project using `swc`, I ran into the following issue.
```
 Error  The value of "val" is out of range. It must be >= 1 && <= 9007199254740991. Received 0
```
After digging through, I was able to figure out that the root cause is the same as https://github.com/piscinajs/piscina/issues/491. Unfortunately I don't have a repro that I can share, but the issue is well-documented in the linked issue.