### PR TITLE
Fix watching relative dirs in `@swc/cli` due to change in `chokidar@v4`

### DIFF
--- a/.changeset/twelve-fishes-roll.md
+++ b/.changeset/twelve-fishes-roll.md
@@ -1,0 +1,5 @@
+---
+"@swc/cli": patch
+---
+
+Fix watching relative dirs in `@swc/cli` due to change in `chokidar@v4`

--- a/packages/cli/src/swc/dir.ts
+++ b/packages/cli/src/swc/dir.ts
@@ -256,9 +256,16 @@ async function watchCompilation(
         outFileExtension,
         quiet,
         sync,
+        only,
+        ignore,
     } = cliOptions;
 
-    const watcher = await watchSources(filenames, includeDotfiles);
+    const watcher = await watchSources(
+        filenames,
+        includeDotfiles,
+        only,
+        ignore
+    );
     watcher.on("ready", () => {
         if (callbacks?.onWatchReady) {
             callbacks.onWatchReady();

--- a/packages/cli/src/swc/sources.ts
+++ b/packages/cli/src/swc/sources.ts
@@ -106,10 +106,20 @@ export async function requireChokidar() {
     }
 }
 
-export async function watchSources(sources: string[], includeDotfiles = false) {
+export async function watchSources(
+    sources: string[],
+    includeDotfiles = false,
+    only: string[] = [],
+    ignore: string[] = [],
+) {
     const chokidar = await requireChokidar();
-
-    return chokidar.watch(sources, {
+    const sourceFiles = await globSources(
+        filenames,
+        only,
+        ignore,
+        includeDotfiles
+    );
+    return chokidar.watch(sourceFiles, {
         ignored: includeDotfiles
             ? undefined
             : (filename: string) => basename(filename).startsWith("."),


### PR DESCRIPTION
When watching on `--out-dir`, `@swc/cli` would compile the sources when a relative path was passed, but watching would immediately exit instead of watch for changes.

Chokidar version 4.x [removes globbing support](https://github.com/paulmillr/chokidar/releases/tag/4.0.0), which means that it does not recursively watch unresolved relative paths with either globbing or cwd. The documentation recommends resolving the glob(s) before passing to `watch`, and has some examples.

Weighing the options, it appeared to be more ergonomic to use `globSources` to resolve the files to watch rather than create a new method of globbing or directly glob the files. This pull request makes a very small change to the parameters of `watchSources`, as I could not cause the error to occur on individual files and wanted to leave that signature alone. However, when watching on `--out-dir`, watching would immediately exit as a relative file did not exist and was not being resolved via globbing anymore.

This restores the ability to pass relative paths and globs to the `swc` command of `@swc/cli` and successfully watch for changes of the source files.