### PR TITLE
chore(counter): fix typo in package.json

### DIFF
--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -3,7 +3,7 @@
     "packageManager": "pnpm@8.6.7",
     "main": "index.js",
     "version": "0.1.3",
-    "description": "Downloade counter for the swc project",
+    "description": "Download counter for the swc project",
     "sideEffects": false,
     "repository": {
         "type": "git",


### PR DESCRIPTION
I fixed the small typo in the package's description.