### PR TITLE
feat: Map typescript input extensions

### DIFF
--- a/packages/cli/src/swc/__tests__/dirWorker.test.ts
+++ b/packages/cli/src/swc/__tests__/dirWorker.test.ts
@@ -1,6 +1,6 @@
 import { Options } from "@swc/core";
 import handleCompile from "../dirWorker";
-import { CliOptions, DEFAULT_OUT_FILE_EXTENSION } from "../options";
+import { CliOptions } from "../options";
 import * as utilModule from "../util";
 import * as compileModule from "../compile";
 import path from "path";
@@ -59,7 +59,7 @@ beforeEach(() => {
 });
 
 describe("dirWorker", () => {
-    it('should call "compile" with the "DEFAULT_OUT_FILE_EXTENSION" when "outFileExtension" is undefined', async () => {
+    it('should call "compile" with the corresponding extension when "outFileExtension" is undefined', async () => {
         const filename = "test";
         const options = createHandleCompileOptions({
             filename: `${filename}.ts`,
@@ -78,7 +78,7 @@ describe("dirWorker", () => {
             options.sync,
             path.join(
                 options.outDir,
-                `${filename}.${DEFAULT_OUT_FILE_EXTENSION}`
+                `${filename}.${utilModule.mapTsExt(options.filename)}`
             )
         );
 
@@ -90,12 +90,15 @@ describe("dirWorker", () => {
             sourceFile: `${filename}.ts`,
             destFile: path.join(
                 options.outDir,
-                `${filename}.${DEFAULT_OUT_FILE_EXTENSION}`
+                `${filename}.${utilModule.mapTsExt(filename)}`
             ),
-            destDtsFile: path.join(options.outDir, `${filename}.d.ts`),
+            destDtsFile: path.join(
+                options.outDir,
+                `${filename}.${utilModule.mapDtsExt(filename)}`
+            ),
             destSourcemapFile: path.join(
                 options.outDir,
-                `${filename}.${DEFAULT_OUT_FILE_EXTENSION}.map`
+                `${filename}.${utilModule.mapTsExt(filename)}.map`
             ),
             options: { sourceFileName: `../${options.filename}` },
         });

--- a/packages/cli/src/swc/__tests__/options.test.ts
+++ b/packages/cli/src/swc/__tests__/options.test.ts
@@ -37,7 +37,7 @@ const createDefaultResult = (): ParserArgsReturn => ({
         outDir: undefined,
         // @ts-expect-error
         outFile: undefined,
-        outFileExtension: "js",
+        outFileExtension: undefined,
         quiet: false,
         sourceMapTarget: undefined,
         stripLeadingPaths: false,
@@ -87,16 +87,6 @@ describe("parserArgs", () => {
                 cliOptions: { outFileExtension: "magic_custom_extension" },
             });
             expect(result).toEqual(expectedOptions);
-        });
-
-        it("provides a sensible default", () => {
-            const args = [
-                "node",
-                "/path/to/node_modules/swc-cli/bin/swc.js",
-                "src",
-            ];
-            const result = parserArgs(args);
-            expect(result!.cliOptions.outFileExtension).toEqual("js");
         });
     });
 

--- a/packages/cli/src/swc/dir.ts
+++ b/packages/cli/src/swc/dir.ts
@@ -5,7 +5,7 @@ import { stderr } from "process";
 import { format } from "util";
 import { CompileStatus } from "./constants";
 import { Callbacks, CliOptions } from "./options";
-import { exists, getDest } from "./util";
+import { exists, getDest, mapTsExt } from "./util";
 import handleCompile from "./dirWorker";
 import {
     globSources,
@@ -270,13 +270,18 @@ async function watchCompilation(
         try {
             if (isCompilableExtension(filename, extensions)) {
                 await unlink(
-                    getDest(filename, outDir, stripLeadingPaths, ".js")
+                    getDest(
+                        filename,
+                        outDir,
+                        stripLeadingPaths,
+                        `.${mapTsExt(filename)}`
+                    )
                 );
                 const sourcemapPath = getDest(
                     filename,
                     outDir,
                     stripLeadingPaths,
-                    ".js.map"
+                    `.${mapTsExt(filename)}.map`
                 );
                 const sourcemapExists = await exists(sourcemapPath);
                 if (sourcemapExists) {

--- a/packages/cli/src/swc/dirWorker.ts
+++ b/packages/cli/src/swc/dirWorker.ts
@@ -1,12 +1,11 @@
 import slash from "slash";
 import { dirname, relative } from "path";
 import { CompileStatus } from "./constants";
-import { compile, getDest } from "./util";
+import { compile, getDest, mapDtsExt, mapTsExt } from "./util";
 import { outputResult } from "./compile";
 
 import type { Options } from "@swc/core";
 import type { CliOptions } from "./options";
-import { DEFAULT_OUT_FILE_EXTENSION } from "./options";
 
 export default async function handleCompile(opts: {
     filename: string;
@@ -20,7 +19,7 @@ export default async function handleCompile(opts: {
         opts.filename,
         opts.outDir,
         opts.cliOptions.stripLeadingPaths,
-        `.${opts.outFileExtension ?? DEFAULT_OUT_FILE_EXTENSION}`
+        `.${opts.outFileExtension ?? mapTsExt(opts.filename)}`
     );
     const sourceFileName = slash(relative(dirname(dest), opts.filename));
 
@@ -33,7 +32,7 @@ export default async function handleCompile(opts: {
             opts.filename,
             opts.outDir,
             opts.cliOptions.stripLeadingPaths,
-            `.d.ts`
+            `.${mapDtsExt(opts.filename)}`
         );
         const destSourcemap = dest + ".map";
         await outputResult({

--- a/packages/cli/src/swc/options.ts
+++ b/packages/cli/src/swc/options.ts
@@ -19,7 +19,6 @@ const DEFAULT_EXTENSIONS = [
 const pkg = require("../../package.json");
 
 let program: Command;
-export const DEFAULT_OUT_FILE_EXTENSION = "js";
 
 export const initProgram = () => {
     program = new commander.Command();
@@ -104,8 +103,7 @@ export const initProgram = () => {
 
     program.option(
         "--out-file-extension [string]",
-        "Use a specific extension for the output files [default: js]",
-        DEFAULT_OUT_FILE_EXTENSION
+        "Use a specific extension for the output files"
     );
 
     program.option(
@@ -267,7 +265,7 @@ export interface CliOptions {
     readonly extensions: string[];
     readonly watch: boolean;
     readonly copyFiles: boolean;
-    readonly outFileExtension: string;
+    readonly outFileExtension?: string;
     readonly includeDotfiles: boolean;
     readonly deleteDirOnStart: boolean;
     readonly quiet: boolean;
@@ -407,7 +405,7 @@ export default function parserArgs(args: string[]) {
         extensions: opts.extensions || DEFAULT_EXTENSIONS,
         watch: !!opts.watch,
         copyFiles: !!opts.copyFiles,
-        outFileExtension: opts.outFileExtension || DEFAULT_OUT_FILE_EXTENSION,
+        outFileExtension: opts.outFileExtension,
         includeDotfiles: !!opts.includeDotfiles,
         deleteDirOnStart: Boolean(opts.deleteDirOnStart),
         quiet: !!opts.quiet,

--- a/packages/cli/src/swc/util.ts
+++ b/packages/cli/src/swc/util.ts
@@ -1,7 +1,7 @@
 import * as swc from "@swc/core";
 import slash from "slash";
 import { mkdirSync, writeFileSync, promises } from "fs";
-import { dirname, join, relative } from "path";
+import { dirname, extname, join, relative } from "path";
 import { stderr } from "process";
 
 export async function exists(path: string): Promise<boolean> {
@@ -157,4 +157,24 @@ export function getDest(
         base = base.replace(/\.\w*$/, ext);
     }
     return join(outDir, base);
+}
+
+export function mapTsExt(filename: string) {
+    return (
+        {
+            ".ts": "js",
+            ".mts": "mjs",
+            ".cts": "cjs",
+        }[extname(filename)] ?? "js"
+    );
+}
+
+export function mapDtsExt(filename: string) {
+    return (
+        {
+            ".ts": "d.ts",
+            ".mts": "d.mts",
+            ".cts": "d.cts",
+        }[extname(filename)] ?? "d.ts"
+    );
 }


### PR DESCRIPTION
will closes https://github.com/swc-project/swc/issues/9800

It seems that swc doesn't rewrite relative import extensions: https://github.com/swc-project/swc/issues/9611, so I think this is a safe change. If I'm missing something please tell me and I will do corresponding changes.