### PR TITLE
fix(cli): rename `sources` to `filenames`

### DIFF
--- a/packages/cli/src/swc/sources.ts
+++ b/packages/cli/src/swc/sources.ts
@@ -107,7 +107,7 @@ export async function requireChokidar() {
 }
 
 export async function watchSources(
-    sources: string[],
+    filenames: string[],
     includeDotfiles = false,
     only: string[] = [],
     ignore: string[] = [],


### PR DESCRIPTION
The `globSources` call was accidentally passed the wrong variable `sources`, so it never received the actual array of file paths. This PR corrects that by passing the `filenames` parameter through to `globSources`.