### PR TITLE
fix(jest): Use greatest known `jsc.target` instead of least

### DIFF
--- a/.changeset/weak-insects-crash.md
+++ b/.changeset/weak-insects-crash.md
@@ -1,0 +1,5 @@
+---
+"@swc/jest": patch
+---
+
+Update default jsc.target for node 22 and future versions

--- a/packages/jest/README.md
+++ b/packages/jest/README.md
@@ -82,6 +82,9 @@ A: By default, the version supported by your Node runtime.
 | 15           | 'es2021'             |
 | 16           | 'es2021'             |
 | 17           | 'es2022'             |
+| 18           | 'es2023'             |
+| 19           | 'es2023'             |
+| 20           | 'es2023'             |
 
 You can customize this by setting an explicit version in `jest.config.js`:
 


### PR DESCRIPTION
I noticed that code coverage was different between node 20 and 22 when using @swc/jest and tracked it back to swc falling back to es2018 for unknown node versions.

This change makes @swc/jest use the target of any lower node version

Fixes #98