### PR TITLE
Propagate extra build info through swc-loader

### DIFF
--- a/.changeset/bright-drinks-tap.md
+++ b/.changeset/bright-drinks-tap.md
@@ -1,0 +1,5 @@
+---
+"swc-loader": patch
+---
+
+Pass through incoming extra build info to output

--- a/packages/swc-loader/src/index.js
+++ b/packages/swc-loader/src/index.js
@@ -1,7 +1,7 @@
 const swc = require("@swc/core");
 
 function makeLoader() {
-    return function (source, inputSourceMap) {
+    return function (source, inputSourceMap, extra) {
         // Make the loader async
         const callback = this.async();
         const filename = this.resourcePath;
@@ -91,7 +91,8 @@ function makeLoader() {
                 callback(
                     null,
                     output.code,
-                    parseMap ? JSON.parse(output.map) : output.map
+                    parseMap ? JSON.parse(output.map) : output.map,
+                    extra
                 );
             } else {
                 swc.transform(source, programmaticOptions).then(
@@ -99,7 +100,8 @@ function makeLoader() {
                         callback(
                             null,
                             output.code,
-                            parseMap ? JSON.parse(output.map) : output.map
+                            parseMap ? JSON.parse(output.map) : output.map,
+                            extra
                         );
                     },
                     (err) => {


### PR DESCRIPTION
# Summary

At Canva, we use some transform steps in our webpack config before `swc-loader` runs, which collects module build info / metadata to be used in the webpack plugins stage. What we noticed is that `swc-loader` is dropping that additional build info for some reason, which means we won't be able to consume it down the line.

Seems like just adding a third parameter to the `makeLoader` returned function and passing it through to the callbacks works correctly.

Let me know if this change looks good!