### PR TITLE
feat(cli): Update chokidar to v5

### DIFF
--- a/.changeset/chokidar-v5-update.md
+++ b/.changeset/chokidar-v5-update.md
@@ -1,0 +1,9 @@
+---
+"@swc/cli": major
+---
+
+Update chokidar to v5
+
+This update resolves peer dependency conflicts in repositories that use both @swc/cli and Angular, as Angular now uses chokidar v5.
+
+BREAKING CHANGE: Minimum Node.js version bumped from 16.14.0 to 20.19.0 to match chokidar v5's requirements.

--- a/.changeset/chokidar-v5-update.md
+++ b/.changeset/chokidar-v5-update.md
@@ -1,9 +1,0 @@
----
-"@swc/cli": major
----
-
-Update chokidar to v5
-
-This update resolves peer dependency conflicts in repositories that use both @swc/cli and Angular, as Angular now uses chokidar v5.
-
-BREAKING CHANGE: Minimum Node.js version bumped from 16.14.0 to 20.19.0 to match chokidar v5's requirements.

--- a/.changeset/stupid-lobsters-film.md
+++ b/.changeset/stupid-lobsters-film.md
@@ -1,0 +1,5 @@
+---
+"@swc/cli": minor
+---
+
+feat(cli): Update chokidar to v5

--- a/.changeset/wise-otters-grow.md
+++ b/.changeset/wise-otters-grow.md
@@ -1,0 +1,5 @@
+---
+"@swc/cli": patch
+---
+
+feat(cli): Update chokidar to v5

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -37,7 +37,7 @@
     },
     "homepage": "https://github.com/swc-project/pkgs",
     "engines": {
-        "node": ">= 16.14.0"
+        "node": ">= 20.19.0"
     },
     "bin": {
         "swc": "./bin/swc.js",
@@ -63,7 +63,7 @@
         "@types/jest": "^29.5.0",
         "@types/node": "^20.11.5",
         "@types/semver": "^7.3.13",
-        "chokidar": "^4.0.1",
+        "chokidar": "^5.0.0",
         "deepmerge": "^4.2.2",
         "jest": "^29.5.0",
         "ts-jest": "^29.0.5",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "@swc/core": "^1.2.66",
-        "chokidar": "^4.0.1"
+        "chokidar": "^5.0.0"
     },
     "peerDependenciesMeta": {
         "chokidar": {

--- a/packages/cli/src/swc/chokidar.d.ts
+++ b/packages/cli/src/swc/chokidar.d.ts
@@ -1,0 +1,65 @@
+/**
+ * Local type declarations for chokidar v5.
+ *
+ * Chokidar v5's FSWatcher extends EventEmitter<T> which requires Node.js 22+ types.
+ * Since we support Node.js 20.19+, we provide a simplified type interface here
+ * that describes the subset of the API we actually use.
+ */
+declare module "chokidar" {
+    import { Stats } from "fs";
+
+    export type AWF = {
+        stabilityThreshold: number;
+        pollInterval: number;
+    };
+
+    export type MatchFunction = (val: string, stats?: Stats) => boolean;
+
+    export interface MatcherObject {
+        path: string;
+        recursive?: boolean;
+    }
+
+    export type Matcher = string | RegExp | MatchFunction | MatcherObject;
+
+    export type ChokidarOptions = {
+        persistent?: boolean;
+        ignoreInitial?: boolean;
+        followSymlinks?: boolean;
+        cwd?: string;
+        usePolling?: boolean;
+        interval?: number;
+        binaryInterval?: number;
+        alwaysStat?: boolean;
+        depth?: number;
+        ignorePermissionErrors?: boolean;
+        atomic?: boolean | number;
+        ignored?: Matcher | Matcher[];
+        awaitWriteFinish?: boolean | Partial<AWF>;
+    };
+
+    export type EmitArgs = [string, Stats?];
+
+    export interface FSWatcher {
+        on(event: "ready", listener: () => void): this;
+        on(event: "add" | "change" | "unlink", listener: (path: string, stats?: Stats) => void): this;
+        on(event: "addDir" | "unlinkDir", listener: (path: string, stats?: Stats) => void): this;
+        on(event: "error", listener: (error: Error) => void): this;
+        on(event: "all", listener: (eventName: string, path: string, stats?: Stats) => void): this;
+        on(event: "raw", listener: (eventName: string, path: string, details: any) => void): this;
+        on(event: string, listener: (...args: any[]) => void): this;
+        add(paths: string | string[]): this;
+        unwatch(paths: string | string[]): this;
+        close(): Promise<void>;
+        getWatched(): Record<string, string[]>;
+    }
+
+    export function watch(paths: string | string[], options?: ChokidarOptions): FSWatcher;
+
+    const _default: {
+        watch: typeof watch;
+        FSWatcher: new (options?: ChokidarOptions) => FSWatcher;
+    };
+
+    export default _default;
+}

--- a/packages/cli/src/swc/sources.ts
+++ b/packages/cli/src/swc/sources.ts
@@ -4,6 +4,8 @@ import { stat } from "fs";
 import { join, basename, extname } from "path";
 import { minimatch } from "minimatch";
 
+import type { FSWatcher } from "chokidar";
+
 /**
  * Find all input files based on source globs
  */
@@ -112,7 +114,7 @@ export async function watchSources(
     includeDotfiles = false,
     only: string[] = [],
     ignore: string[] = []
-) {
+): Promise<FSWatcher> {
     const chokidar = await requireChokidar();
     return chokidar.watch(sources, {
         ignored: (filename: string) => {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,6 +3,7 @@
         "target": "es2019",
         "module": "commonjs",
         "strict": true,
+        "skipLibCheck": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noImplicitReturns": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
     devDependencies:
       '@swc/cli':
         specifier: 0.7.9
-        version: 0.7.9(@swc/core@1.6.4)(chokidar@4.0.1)
+        version: 0.7.9(@swc/core@1.6.4)(chokidar@5.0.0)
       '@swc/core':
         specifier: ^1.6.4
         version: 1.6.4
@@ -85,8 +85,8 @@ importers:
         specifier: ^7.3.13
         version: 7.3.13
       chokidar:
-        specifier: ^4.0.1
-        version: 4.0.1
+        specifier: ^5.0.0
+        version: 5.0.0
       deepmerge:
         specifier: ^4.2.2
         version: 4.2.2
@@ -104,19 +104,19 @@ importers:
     dependencies:
       '@swc/cli':
         specifier: file:../..
-        version: file:packages/cli(@swc/core@1.11.24)(chokidar@4.0.1)
+        version: file:packages/cli(@swc/core@1.11.24)(chokidar@5.0.0)
 
   packages/cli/examples/spack-multiple-entry:
     dependencies:
       '@swc/cli':
         specifier: file:../..
-        version: file:packages/cli(@swc/core@1.11.24)(chokidar@4.0.1)
+        version: file:packages/cli(@swc/core@1.11.24)(chokidar@5.0.0)
 
   packages/cli/examples/spack-node-modules:
     dependencies:
       '@swc/cli':
         specifier: file:../..
-        version: file:packages/cli(@swc/core@1.11.24)(chokidar@4.0.1)
+        version: file:packages/cli(@swc/core@1.11.24)(chokidar@5.0.0)
       path:
         specifier: ^0.12.7
         version: 0.12.7
@@ -1219,11 +1219,11 @@ packages:
 
   '@swc/cli@file:packages/cli':
     resolution: {directory: packages/cli, type: directory}
-    engines: {node: '>= 16.14.0'}
+    engines: {node: '>= 20.19.0'}
     hasBin: true
     peerDependencies:
       '@swc/core': ^1.2.66
-      chokidar: ^4.0.1
+      chokidar: ^5.0.0
     peerDependenciesMeta:
       chokidar:
         optional: true
@@ -2099,9 +2099,9 @@ packages:
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
-  chokidar@4.0.1:
-    resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
-    engines: {node: '>= 14.16.0'}
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -4670,9 +4670,9 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
-  readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -7156,7 +7156,7 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@swc/cli@0.7.9(@swc/core@1.6.4)(chokidar@4.0.1)':
+  '@swc/cli@0.7.9(@swc/core@1.6.4)(chokidar@5.0.0)':
     dependencies:
       '@swc/core': 1.6.4
       '@swc/counter': 0.1.3
@@ -7169,9 +7169,9 @@ snapshots:
       source-map: 0.7.4
       tinyglobby: 0.2.13
     optionalDependencies:
-      chokidar: 4.0.1
+      chokidar: 5.0.0
 
-  '@swc/cli@file:packages/cli(@swc/core@1.11.24)(chokidar@4.0.1)':
+  '@swc/cli@file:packages/cli(@swc/core@1.11.24)(chokidar@5.0.0)':
     dependencies:
       '@swc/core': 1.11.24
       '@swc/counter': link:packages/counter
@@ -7184,7 +7184,7 @@ snapshots:
       source-map: 0.7.4
       tinyglobby: 0.2.13
     optionalDependencies:
-      chokidar: 4.0.1
+      chokidar: 5.0.0
 
   '@swc/core-darwin-arm64@1.11.24':
     optional: true
@@ -8135,9 +8135,9 @@ snapshots:
 
   chardet@0.7.0: {}
 
-  chokidar@4.0.1:
+  chokidar@5.0.0:
     dependencies:
-      readdirp: 4.1.2
+      readdirp: 5.0.0
 
   chownr@2.0.0: {}
 
@@ -11463,7 +11463,7 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  readdirp@4.1.2: {}
+  readdirp@5.0.0: {}
 
   redent@3.0.0:
     dependencies:


### PR DESCRIPTION
This update resolves peer dependency conflicts in repositories that use
both @swc/cli and Angular, as Angular now uses chokidar v5.

BREAKING CHANGE: Minimum Node.js version bumped from 16.14.0 to 20.19.0
to match chokidar v5's requirements.

Changes:
- Update chokidar from ^4.0.1 to ^5.0.0 in devDependencies and peerDependencies
- Add local type declarations for chokidar to support Node.js 20.19+
  (chokidar v5 types use Node.js 22+ generic EventEmitter)
- Add skipLibCheck to tsconfig.json for type compatibility
- Add explicit FSWatcher return type to watchSources function
