### PR TITLE
chore(ci): add node 24 (lts) to the test matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
 
     steps:
       - name: Check out code


### PR DESCRIPTION
I noticed this project wasn't running tests against Node 24, which is the LTS version.